### PR TITLE
fixed `partial is undefined` bug from templates

### DIFF
--- a/styleguide/src/partials/template.html
+++ b/styleguide/src/partials/template.html
@@ -4,12 +4,16 @@
     and in case changes are made in the future.
   `html` is used to pass HTML in from javascript, mainly for tests
     (surrounding tildas trim whitespace '\n', needed for tests)
-  `partial-block` will output output the nested content
-    when this partial is used in another handlebars template.
+  `partial` is a reference to a full handlebars partial to be output
+  `partial-block` will output the nested content
+     when this partial is used in another handlebars template.
 --}}
 
 <template id="{{id}}">
   {{~{html}~}}
+  {{#if partial }}
+    {{> (lookup . 'partial')}}
+  {{/if}}
   {{#if @partial-block}}
     {{> @partial-block }}
   {{/if}}

--- a/styleguide/ui/layouts/includes/mock-templates.html
+++ b/styleguide/ui/layouts/includes/mock-templates.html
@@ -1,13 +1,3 @@
 {{#each templates }}
-
-  {{!-- get the template, and add it to an inline partial, because scope --}}
-  {{#*inline "templateHTML"}}
-    {{> (lookup ../templates @index)}}
-  {{/inline}}
-
-  {{!-- write the template partial, along with its HTML --}}
-  {{#> template id=this }}
-    {{> templateHTML}}
-  {{/template}}
-
+  {{> template id=this partial=this }}
 {{/each}}


### PR DESCRIPTION
- further complicated `template.html`, now accepting a partial by name
- simplified `mock-templates.html` by simply passing in the partial name,
    and letting the `template` partial resolve it